### PR TITLE
#11 replace set-output statement GITHUB_OUTPUT

### DIFF
--- a/src/yaml_lint.sh
+++ b/src/yaml_lint.sh
@@ -42,7 +42,7 @@ ${lint_output}
         echo "${lint_payload}" | curl -s -S -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" --header "Content-Type: application/json" --data @- "${lint_comment_url}" > /dev/null
     fi
 
-    echo ::set-output name=yamllint_output::${lint_output}
+    echo "yamllint_output=${lint_output}" >> $GITHUB_OUTPUT
     exit ${lint_exit_code}
 }
 


### PR DESCRIPTION
## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

This is a patch to use `$GITHUB_OUTPUT` instead of `set-output`.

## Other information:

* https://github.com/karancode/yamllint-github-action/issues/11
* [GitHub Actions: Deprecating save-state and set-output commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
